### PR TITLE
Bug#218 Update shaping rate help

### DIFF
--- a/templates/traffic-policy/shaper/node.tag/bandwidth/node.def
+++ b/templates/traffic-policy/shaper/node.tag/bandwidth/node.def
@@ -6,4 +6,7 @@ syntax:expression: $VAR(@) == "auto" || \
 
 val_help: auto; Rate matches interface speed (default)
 val_help: <number>; Rate in k (1000) bytes per second 
-val_help: <number><suffix>;  Rate with scaling suffix (mbit, mbps, ...)
+val_help: <number>bit; bit(1), kbit(10^3), mbit(10^6), gbit, tbit
+val_help: <number>ibit; kibit(1024), mibit(1024^2), gibit(1024^3), tbit(1024^4)
+val_help: <number>ibps; kibps(1024*8), mibps(1024^2*8), gibps, tibps *Byte/sec*
+val_help: <number>bps; bps(8),kbps(8*10^3),mbps(8*10^6), gbps, tbps *Byte/sec*

--- a/templates/traffic-policy/shaper/node.tag/class/node.tag/bandwidth/node.def
+++ b/templates/traffic-policy/shaper/node.tag/class/node.tag/bandwidth/node.def
@@ -2,6 +2,9 @@ type: txt
 default: "100%"
 help: Bandwidth used for this class
 syntax:expression: exec "/opt/vyatta/sbin/vyatta-qos-util.pl --percent-or-rate $VAR(@)"
-val_help: <number>; Bandwidth in Kbps
+val_help: <number>; Bandwidth in Kbps(10^3 bits per second)
 val_help: <number>%%; Percentage of overall rate (default 100%%)
-val_help: <number><suffix>;  Value with scaling suffix (kbit, kbps, ...)
+val_help: <number>bit; bit(1), kbit(10^3), mbit(10^6), gbit, tbit
+val_help: <number>ibit; kibit(1024), mibit(1024^2), gibit(1024^3), tbit(1024^4)
+val_help: <number>ibps; kibps(1024*8), mibps(1024^2*8), gibps, tibps *Byte/sec*
+val_help: <number>bps; bps(8),kbps(8*10^3),mbps(8*10^6), gbps, tbps *Byte/sec*

--- a/templates/traffic-policy/shaper/node.tag/class/node.tag/ceiling/node.def
+++ b/templates/traffic-policy/shaper/node.tag/class/node.tag/ceiling/node.def
@@ -2,6 +2,9 @@ type: txt
 help: Bandwidth limit for this class
 syntax:expression: exec "/opt/vyatta/sbin/vyatta-qos-util.pl --percent-or-rate $VAR(@)"
 
-val_help: <number>; Bandwidth in Kbps
+val_help: <number>; Bandwidth in Kbps(10^3 bits per second)
 val_help: <number>%%; Percentage of overall rate (default 100%%)
-val_help: <number><suffix>;  Value with scaling suffix (kbit, kbps, ...)
+val_help: <number>bit; bit(1), kbit(10^3), mbit(10^6), gbit, tbit
+val_help: <number>ibit; kibit(1024), mibit(1024^2), gibit(1024^3), tbit(1024^4)
+val_help: <number>ibps; kibps(1024*8), mibps(1024^2*8), gibps, tibps *Byte/sec*
+val_help: <number>bps; bps(8),kbps(8*10^3),mbps(8*10^6), gbps, tbps *Byte/sec*

--- a/templates/traffic-policy/shaper/node.tag/default/bandwidth/node.def
+++ b/templates/traffic-policy/shaper/node.tag/default/bandwidth/node.def
@@ -2,6 +2,9 @@ type: txt
 help: Bandwidth used for default traffic [REQUIRED]
 syntax:expression: exec "/opt/vyatta/sbin/vyatta-qos-util.pl --percent-or-rate \$VAR(@)"
 
-val_help: <number>; Bandwidth in Kbps
+val_help: <number>; Bandwidth in Kbps(10^3 bits per second)
 val_help: <number>%%; Percentage of overall rate (default 100%%)
-val_help: <number><suffix>;  Value with scaling suffix (kbit, kbps, ...)
+val_help: <number>bit; bit(1), kbit(10^3), mbit(10^6), gbit, tbit
+val_help: <number>ibit; kibit(1024), mibit(1024^2), gibit(1024^3), tbit(1024^4)
+val_help: <number>ibps; kibps(1024*8), mibps(1024^2*8), gibps, tibps *Byte/sec*
+val_help: <number>bps; bps(8),kbps(8*10^3),mbps(8*10^6), gbps, tbps *Byte/sec*

--- a/templates/traffic-policy/shaper/node.tag/default/ceiling/node.def
+++ b/templates/traffic-policy/shaper/node.tag/default/ceiling/node.def
@@ -2,6 +2,9 @@ type: txt
 help: Bandwidth limit for default traffic
 syntax:expression: exec "/opt/vyatta/sbin/vyatta-qos-util.pl --percent-or-rate $VAR(@)"
 
-val_help: <number>; Bandwidth in Kbps
+val_help: <number>; Bandwidth in Kbps(10^3 bits per second)
 val_help: <number>%%; Percentage of overall rate (default 100%%)
-val_help: <number><suffix>;  Value with scaling suffix (kbit, kbps, ...)
+val_help: <number>bit; bit(1), kbit(10^3), mbit(10^6), gbit, tbit
+val_help: <number>ibit; kibit(1024), mibit(1024^2), gibit(1024^3), tbit(1024^4)
+val_help: <number>ibps; kibps(1024*8), mibps(1024^2*8), gibps, tibps *Byte/sec*
+val_help: <number>bps; bps(8),kbps(8*10^3),mbps(8*10^6), gbps, tbps *Byte/sec*


### PR DESCRIPTION
Repoted by Mr Kentaro Ebisawa.

  http://blog.ebiken.me/vyos-traffic-policy-conf-bitbyte/
  (Japanese page)

This help is hard to understand. 

```
vyos@vyos# set traffic-policy shaper ICMP-OUTGOING default bandwidth 500Mbps
Possible completions:
    <number>     Bandwidth in Kbps
    <number>%    Percentage of overall rate (default 100%)
    <number><suffix>
                Value with scaling suffix (kbit, kbps, ...)
```

I updated help.

After

```
vyos@vyos# set traffic-policy shaper ICMP-OUTGOING default bandwidth 500Mbps
Possible completions:
   <number>     Bandwidth in Kbps(10^3 bits per second)
   <number>%    Percentage of overall rate (default 100%)
   <number>bit  bit(1), kbit(10^3), mbit(10^6), gbit, tbit
   <number>ibit kibit(1024), mibit(1024^2), gibit(1024^3), tbit(1024^4)
   <number>ibps kibps(1024*8), mibps(1024^2*8), gibps, tibps *Byte/sec*
   <number>bps  bps(8),kbps(8*10^3),mbps(8*10^6), gbps, tbps *Byte/sec*
```
