### PR TITLE
T1050: Wrong queue-limit for fair-queue

### DIFF
--- a/templates/traffic-policy/fair-queue/node.tag/queue-limit/node.def
+++ b/templates/traffic-policy/fair-queue/node.tag/queue-limit/node.def
@@ -1,5 +1,5 @@
 type: u32
 help: Maximum queue size (packets)
-syntax:expression: $VAR(@) > 1 && $VAR(@) < 128;\
-    "Queue limit must greater than 1 and less than 128"
-val_help: u32:1-127; Queue size in packets
+syntax:expression: $VAR(@) > 1 && $VAR(@) < 65536;\
+    "Queue limit must greater than 1 and less than 65536"
+val_help: u32:1-65535; Queue size in packets


### PR DESCRIPTION
Raised queue-limit from 127 to 65535