### PR TITLE
qos: T2572: fix default tc units

### DIFF
--- a/templates/traffic-policy/limiter/node.tag/class/node.tag/bandwidth/node.def
+++ b/templates/traffic-policy/limiter/node.tag/class/node.tag/bandwidth/node.def
@@ -2,5 +2,5 @@ type: txt
 help: Traffic-limit used for this class [REQUIRED]
 syntax:expression: exec "/opt/vyatta/sbin/vyatta-qos-util.pl --rate $VAR(@)"
 
-val_help: <number>; Rate in k (1000) bytes per second 
+val_help: <number>; Rate in kbit (kilobit per second) 
 val_help: <number><suffix>;  Rate with scaling suffix (mbit, mbps, ...)

--- a/templates/traffic-policy/limiter/node.tag/default/bandwidth/node.def
+++ b/templates/traffic-policy/limiter/node.tag/default/bandwidth/node.def
@@ -2,5 +2,5 @@ type: txt
 help: Traffic-limit used for this class
 syntax:expression: exec "/opt/vyatta/sbin/vyatta-qos-util.pl --rate $VAR(@)"
 
-val_help: <number>; Rate in k (1000) bytes per second 
+val_help: <number>; Rate in kbit (kilobit per second) 
 val_help: <number><suffix>;  Rate with scaling suffix (mbit, mbps, ...)

--- a/templates/traffic-policy/network-emulator/node.tag/bandwidth/node.def
+++ b/templates/traffic-policy/network-emulator/node.tag/bandwidth/node.def
@@ -2,5 +2,5 @@ type: txt
 help: Bandwidth limit
 syntax:expression: exec "/opt/vyatta/sbin/vyatta-qos-util.pl --rate $VAR(@)"
 
-val_help: <number>; Rate in k (1000) bytes per second 
+val_help: <number>; Rate in kbit (kilobit per second) 
 val_help: <number><suffix>;  Rate with scaling suffix (mbit, mbps, ...)

--- a/templates/traffic-policy/random-detect/node.tag/bandwidth/node.def
+++ b/templates/traffic-policy/random-detect/node.tag/bandwidth/node.def
@@ -4,5 +4,4 @@ default: "auto"
 syntax:expression: $VAR(@) == "auto" || \
 		   exec "/opt/vyatta/sbin/vyatta-qos-util.pl --rate $VAR(@)"
 val_help: auto; Rate based on interface speed (default)
-val_help: <number>; Rate in k (1000) bytes per second 
 val_help: <number><suffix>;  Rate with scaling suffix (mbit, mbps, ...)

--- a/templates/traffic-policy/rate-control/node.tag/bandwidth/node.def
+++ b/templates/traffic-policy/rate-control/node.tag/bandwidth/node.def
@@ -2,5 +2,5 @@ type: txt
 help: Bandwidth limit
 syntax:expression: exec "/opt/vyatta/sbin/vyatta-qos-util.pl --rate $VAR(@)"
 
-val_help: <number>; Rate in k (1000) bytes per second 
+val_help: <number>; Rate in kbit (kilobit per second) 
 val_help: <number><suffix>;  Rate with scaling suffix (mbit, mbps, ...)

--- a/templates/traffic-policy/shaper-hfsc/node.tag/bandwidth/node.def
+++ b/templates/traffic-policy/shaper-hfsc/node.tag/bandwidth/node.def
@@ -5,7 +5,7 @@ syntax:expression: $VAR(@) == "auto" || \
 		   exec "/opt/vyatta/sbin/vyatta-qos-util.pl --rate $VAR(@)"
 
 val_help: auto; Rate matches interface speed (default)
-val_help: <number>; Rate in k (1000) bytes per second 
+val_help: <number>; Rate in kbit (kilobit per second) 
 val_help: <number>bit; bit(1), kbit(10^3), mbit(10^6), gbit, tbit
 val_help: <number>ibit; kibit(1024), mibit(1024^2), gibit(1024^3), tbit(1024^4)
 val_help: <number>ibps; kibps(1024*8), mibps(1024^2*8), gibps, tibps *Byte/sec*

--- a/templates/traffic-policy/shaper-hfsc/node.tag/class/node.tag/linkshare/m1/node.def
+++ b/templates/traffic-policy/shaper-hfsc/node.tag/class/node.tag/linkshare/m1/node.def
@@ -2,7 +2,7 @@ type: txt
 help: Linkshare m1 parameter for class traffic
 syntax:expression: exec "/opt/vyatta/sbin/vyatta-qos-util.pl --percent-or-rate $VAR(@)"
 
-val_help: <number>; Bandwidth in Kbps(10^3 bits per second)
+val_help: <number>; Rate in kbit (kilobit per second)
 val_help: <number>%%; Percentage of overall rate (default 100%%)
 val_help: <number>bit; bit(1), kbit(10^3), mbit(10^6), gbit, tbit
 val_help: <number>ibit; kibit(1024), mibit(1024^2), gibit(1024^3), tbit(1024^4)

--- a/templates/traffic-policy/shaper-hfsc/node.tag/class/node.tag/linkshare/m2/node.def
+++ b/templates/traffic-policy/shaper-hfsc/node.tag/class/node.tag/linkshare/m2/node.def
@@ -2,7 +2,7 @@ type: txt
 help: Linkshare m2 traffic for class traffic
 syntax:expression: exec "/opt/vyatta/sbin/vyatta-qos-util.pl --percent-or-rate $VAR(@)"
 
-val_help: <number>; Bandwidth in Kbps(10^3 bits per second)
+val_help: <number>; Rate in kbit (kilobit per second)
 val_help: <number>%%; Percentage of overall rate (default 100%%)
 val_help: <number>bit; bit(1), kbit(10^3), mbit(10^6), gbit, tbit
 val_help: <number>ibit; kibit(1024), mibit(1024^2), gibit(1024^3), tbit(1024^4)

--- a/templates/traffic-policy/shaper-hfsc/node.tag/class/node.tag/realtime/m1/node.def
+++ b/templates/traffic-policy/shaper-hfsc/node.tag/class/node.tag/realtime/m1/node.def
@@ -2,7 +2,7 @@ type: txt
 help: Realtime m1 traffic for class traffic
 syntax:expression: exec "/opt/vyatta/sbin/vyatta-qos-util.pl --percent-or-rate $VAR(@)"
 
-val_help: <number>; Bandwidth in Kbps(10^3 bits per second)
+val_help: <number>; Rate in kbit (kilobit per second)
 val_help: <number>%%; Percentage of overall rate (default 100%%)
 val_help: <number>bit; bit(1), kbit(10^3), mbit(10^6), gbit, tbit
 val_help: <number>ibit; kibit(1024), mibit(1024^2), gibit(1024^3), tbit(1024^4)

--- a/templates/traffic-policy/shaper-hfsc/node.tag/class/node.tag/realtime/m2/node.def
+++ b/templates/traffic-policy/shaper-hfsc/node.tag/class/node.tag/realtime/m2/node.def
@@ -2,7 +2,7 @@ type: txt
 help: Realtime m2 traffic for class traffic
 syntax:expression: exec "/opt/vyatta/sbin/vyatta-qos-util.pl --percent-or-rate $VAR(@)"
 
-val_help: <number>; Bandwidth in Kbps(10^3 bits per second)
+val_help: <number>; Rate in kbit (kilobit per second)
 val_help: <number>%%; Percentage of overall rate (default 100%%)
 val_help: <number>bit; bit(1), kbit(10^3), mbit(10^6), gbit, tbit
 val_help: <number>ibit; kibit(1024), mibit(1024^2), gibit(1024^3), tbit(1024^4)

--- a/templates/traffic-policy/shaper-hfsc/node.tag/class/node.tag/upperlimit/m1/node.def
+++ b/templates/traffic-policy/shaper-hfsc/node.tag/class/node.tag/upperlimit/m1/node.def
@@ -2,7 +2,7 @@ type: txt
 help: Upperlimit m1 traffic for class traffic
 syntax:expression: exec "/opt/vyatta/sbin/vyatta-qos-util.pl --percent-or-rate $VAR(@)"
 
-val_help: <number>; Bandwidth in Kbps(10^3 bits per second)
+val_help: <number>; Rate in kbit (kilobit per second)
 val_help: <number>%%; Percentage of overall rate (default 100%%)
 val_help: <number>bit; bit(1), kbit(10^3), mbit(10^6), gbit, tbit
 val_help: <number>ibit; kibit(1024), mibit(1024^2), gibit(1024^3), tbit(1024^4)

--- a/templates/traffic-policy/shaper-hfsc/node.tag/class/node.tag/upperlimit/m2/node.def
+++ b/templates/traffic-policy/shaper-hfsc/node.tag/class/node.tag/upperlimit/m2/node.def
@@ -2,7 +2,7 @@ type: txt
 help: Upperlimit m2 traffic for class traffic
 syntax:expression: exec "/opt/vyatta/sbin/vyatta-qos-util.pl --percent-or-rate $VAR(@)"
 
-val_help: <number>; Bandwidth in Kbps(10^3 bits per second)
+val_help: <number>; Rate in kbit (kilobit per second)
 val_help: <number>%%; Percentage of overall rate (default 100%%)
 val_help: <number>bit; bit(1), kbit(10^3), mbit(10^6), gbit, tbit
 val_help: <number>ibit; kibit(1024), mibit(1024^2), gibit(1024^3), tbit(1024^4)

--- a/templates/traffic-policy/shaper-hfsc/node.tag/default/linkshare/m1/node.def
+++ b/templates/traffic-policy/shaper-hfsc/node.tag/default/linkshare/m1/node.def
@@ -2,7 +2,7 @@ type: txt
 help: Linkshare m1 parameter for default traffic
 syntax:expression: exec "/opt/vyatta/sbin/vyatta-qos-util.pl --percent-or-rate $VAR(@)"
 
-val_help: <number>; Bandwidth in Kbps(10^3 bits per second)
+val_help: <number>; Rate in kbit (kilobit per second)
 val_help: <number>%%; Percentage of overall rate (default 100%%)
 val_help: <number>bit; bit(1), kbit(10^3), mbit(10^6), gbit, tbit
 val_help: <number>ibit; kibit(1024), mibit(1024^2), gibit(1024^3), tbit(1024^4)

--- a/templates/traffic-policy/shaper-hfsc/node.tag/default/linkshare/m2/node.def
+++ b/templates/traffic-policy/shaper-hfsc/node.tag/default/linkshare/m2/node.def
@@ -2,7 +2,7 @@ type: txt
 help: Linkshare m2 parameter for default queue
 syntax:expression: exec "/opt/vyatta/sbin/vyatta-qos-util.pl --percent-or-rate $VAR(@)"
 
-val_help: <number>; Bandwidth in Kbps(10^3 bits per second)
+val_help: <number>; Rate in kbit (kilobit per second)
 val_help: <number>%%; Percentage of overall rate (default 100%%)
 val_help: <number>bit; bit(1), kbit(10^3), mbit(10^6), gbit, tbit
 val_help: <number>ibit; kibit(1024), mibit(1024^2), gibit(1024^3), tbit(1024^4)

--- a/templates/traffic-policy/shaper-hfsc/node.tag/default/realtime/m1/node.def
+++ b/templates/traffic-policy/shaper-hfsc/node.tag/default/realtime/m1/node.def
@@ -2,7 +2,7 @@ type: txt
 help: Realtime m1 parameter for default traffic
 syntax:expression: exec "/opt/vyatta/sbin/vyatta-qos-util.pl --percent-or-rate $VAR(@)"
 
-val_help: <number>; Bandwidth in Kbps(10^3 bits per second)
+val_help: <number>; Rate in kbit (kilobit per second)
 val_help: <number>%%; Percentage of overall rate (default 100%%)
 val_help: <number>bit; bit(1), kbit(10^3), mbit(10^6), gbit, tbit
 val_help: <number>ibit; kibit(1024), mibit(1024^2), gibit(1024^3), tbit(1024^4)

--- a/templates/traffic-policy/shaper-hfsc/node.tag/default/realtime/m2/node.def
+++ b/templates/traffic-policy/shaper-hfsc/node.tag/default/realtime/m2/node.def
@@ -2,7 +2,7 @@ type: txt
 help: Realtime m2 parameter default traffic
 syntax:expression: exec "/opt/vyatta/sbin/vyatta-qos-util.pl --percent-or-rate $VAR(@)"
 
-val_help: <number>; Bandwidth in Kbps(10^3 bits per second)
+val_help: <number>; Rate in kbit (kilobit per second)
 val_help: <number>%%; Percentage of overall rate (default 100%%)
 val_help: <number>bit; bit(1), kbit(10^3), mbit(10^6), gbit, tbit
 val_help: <number>ibit; kibit(1024), mibit(1024^2), gibit(1024^3), tbit(1024^4)

--- a/templates/traffic-policy/shaper-hfsc/node.tag/default/upperlimit/m1/node.def
+++ b/templates/traffic-policy/shaper-hfsc/node.tag/default/upperlimit/m1/node.def
@@ -2,7 +2,7 @@ type: txt
 help: Upperlimit m1 parameter for default traffic
 syntax:expression: exec "/opt/vyatta/sbin/vyatta-qos-util.pl --percent-or-rate $VAR(@)"
 
-val_help: <number>; Bandwidth in Kbps(10^3 bits per second)
+val_help: <number>; Rate in kbit (kilobit per second)
 val_help: <number>%%; Percentage of overall rate (default 100%%)
 val_help: <number>bit; bit(1), kbit(10^3), mbit(10^6), gbit, tbit
 val_help: <number>ibit; kibit(1024), mibit(1024^2), gibit(1024^3), tbit(1024^4)

--- a/templates/traffic-policy/shaper-hfsc/node.tag/default/upperlimit/m2/node.def
+++ b/templates/traffic-policy/shaper-hfsc/node.tag/default/upperlimit/m2/node.def
@@ -2,7 +2,7 @@ type: txt
 help: Upperlimit m2 parameter for default traffic
 syntax:expression: exec "/opt/vyatta/sbin/vyatta-qos-util.pl --percent-or-rate $VAR(@)"
 
-val_help: <number>; Bandwidth in Kbps(10^3 bits per second)
+val_help: <number>; Rate in kbit (kilobit per second)
 val_help: <number>%%; Percentage of overall rate (default 100%%)
 val_help: <number>bit; bit(1), kbit(10^3), mbit(10^6), gbit, tbit
 val_help: <number>ibit; kibit(1024), mibit(1024^2), gibit(1024^3), tbit(1024^4)

--- a/templates/traffic-policy/shaper/node.tag/bandwidth/node.def
+++ b/templates/traffic-policy/shaper/node.tag/bandwidth/node.def
@@ -5,7 +5,7 @@ syntax:expression: $VAR(@) == "auto" || \
 		   exec "/opt/vyatta/sbin/vyatta-qos-util.pl --rate $VAR(@)"
 
 val_help: auto; Rate matches interface speed (default)
-val_help: <number>; Rate in k (1000) bytes per second 
+val_help: <number>; Rate in kbit (kilobit per second) 
 val_help: <number>bit; bit(1), kbit(10^3), mbit(10^6), gbit, tbit
 val_help: <number>ibit; kibit(1024), mibit(1024^2), gibit(1024^3), tbit(1024^4)
 val_help: <number>ibps; kibps(1024*8), mibps(1024^2*8), gibps, tibps *Byte/sec*

--- a/templates/traffic-policy/shaper/node.tag/class/node.tag/bandwidth/node.def
+++ b/templates/traffic-policy/shaper/node.tag/class/node.tag/bandwidth/node.def
@@ -2,7 +2,7 @@ type: txt
 default: "100%"
 help: Bandwidth used for this class
 syntax:expression: exec "/opt/vyatta/sbin/vyatta-qos-util.pl --percent-or-rate $VAR(@)"
-val_help: <number>; Bandwidth in Kbps(10^3 bits per second)
+val_help: <number>; Bandwidth in kbit (kilobit per second)
 val_help: <number>%%; Percentage of overall rate (default 100%%)
 val_help: <number>bit; bit(1), kbit(10^3), mbit(10^6), gbit, tbit
 val_help: <number>ibit; kibit(1024), mibit(1024^2), gibit(1024^3), tbit(1024^4)

--- a/templates/traffic-policy/shaper/node.tag/default/bandwidth/node.def
+++ b/templates/traffic-policy/shaper/node.tag/default/bandwidth/node.def
@@ -2,7 +2,7 @@ type: txt
 help: Bandwidth used for default traffic [REQUIRED]
 syntax:expression: exec "/opt/vyatta/sbin/vyatta-qos-util.pl --percent-or-rate \$VAR(@)"
 
-val_help: <number>; Bandwidth in Kbps(10^3 bits per second)
+val_help: <number>; Bandwidth in kbit (kilobit per second)
 val_help: <number>%%; Percentage of overall rate (default 100%%)
 val_help: <number>bit; bit(1), kbit(10^3), mbit(10^6), gbit, tbit
 val_help: <number>ibit; kibit(1024), mibit(1024^2), gibit(1024^3), tbit(1024^4)


### PR DESCRIPTION
Fix every wrong default unit in rates for Limiter, Network Emulator, Rate Control,
Shaper and Shaper HFSC.
Delete default unit help for Random Detect.