### PR TITLE
traffic-policy: T4618: Set correct priority for traffic-policy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 VyOS maintainers and contributors
+// Copyright (C) 2020-2021 VyOS maintainers and contributors
 //
 // This program is free software; you can redistribute it and/or modify
 // in order to easy exprort images built to "external" world
@@ -12,13 +12,12 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 @NonCPS
 
 // Using a version specifier library, use 'current' branch. The underscore (_)
 // is not a typo! You need this underscore if the line immediately after the
 // @Library annotation is not an import statement!
-@Library('vyos-build@current')_
+@Library('vyos-build@equuleus')_
 
-// Start package build using library function from https://github.com/c-po/vyos-build
+// Start package build using library function from https://github.com/vyos/vyos-build
 buildPackage()

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+vyatta-cfg-qos (1.3-1) unstable; urgency=medium
+
+  * New LTS branch.
+
+ -- Daniil Baturin <daniil@vyos.io>  Mon, 04 Jan 2021 17:08:09 +0200
+
 vyatta-cfg-qos (0.15.42+vyos2+current1) unstable; urgency=medium
 
   [ Thomas Jepp ]

--- a/debian/vyatta-cfg-qos.install
+++ b/debian/vyatta-cfg-qos.install
@@ -16,5 +16,5 @@ opt/vyatta/share/vyatta-cfg/templates/interfaces/pseudo-ethernet
 opt/vyatta/share/vyatta-cfg/templates/interfaces/tunnel
 opt/vyatta/share/vyatta-cfg/templates/interfaces/vti
 opt/vyatta/share/vyatta-cfg/templates/interfaces/wireless
-opt/vyatta/share/vyatta-cfg/templates/interfaces/wirelessmodem
+opt/vyatta/share/vyatta-cfg/templates/interfaces/wwan
 opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard

--- a/debian/vyatta-cfg-qos.install
+++ b/debian/vyatta-cfg-qos.install
@@ -17,4 +17,5 @@ opt/vyatta/share/vyatta-cfg/templates/interfaces/tunnel
 opt/vyatta/share/vyatta-cfg/templates/interfaces/vti
 opt/vyatta/share/vyatta-cfg/templates/interfaces/wireless
 opt/vyatta/share/vyatta-cfg/templates/interfaces/wwan
+opt/vyatta/share/vyatta-cfg/templates/interfaces/macsec
 opt/vyatta/share/vyatta-cfg/templates/interfaces/wireguard

--- a/gen-interface-templates.pl
+++ b/gen-interface-templates.pl
@@ -46,13 +46,12 @@ my %interface_hash = (
     'vti/node.tag'                                  => '$VAR(@)',
     'bridge/node.tag'                               => '$VAR(@)',
     'openvpn/node.tag'                              => '$VAR(@)',
-    'input/node.tag'				    => '$VAR(@)',
+    'input/node.tag'				                => '$VAR(@)',
 
     'l2tpv3/node.tag'                               => '$VAR(@)',
     'dummy/node.tag'                                => '$VAR(@)',
-
-    'wirelessmodem/node.tag'                        => '$VAR(@)',
-    'wireless/node.tag'  	                    => '$VAR(@)',
+    'wwan/node.tag'                                 => '$VAR(@)',
+    'wireless/node.tag'  	                        => '$VAR(@)',
     'wireless/node.tag/vif/node.tag'                => '$VAR(../@).$VAR(@)',
     'wireguard/node.tag'                            => '$VAR(@)'
 );

--- a/gen-interface-templates.pl
+++ b/gen-interface-templates.pl
@@ -50,6 +50,7 @@ my %interface_hash = (
 
     'l2tpv3/node.tag'                               => '$VAR(@)',
     'dummy/node.tag'                                => '$VAR(@)',
+    'macsec/node.tag'                               => '$VAR(@)',
     'wwan/node.tag'                                 => '$VAR(@)',
     'wireless/node.tag'  	                        => '$VAR(@)',
     'wireless/node.tag/vif/node.tag'                => '$VAR(../@).$VAR(@)',

--- a/templates-skeleton/interface-templates/traffic-policy/in/node.def
+++ b/templates-skeleton/interface-templates/traffic-policy/in/node.def
@@ -1,4 +1,5 @@
 type: txt
+priority: 620
 help: Ingress traffic policy for interface
 allowed: /opt/vyatta/sbin/vyatta-qos.pl --list-policy in
 update: /opt/vyatta/sbin/vyatta-qos.pl --update-interface $IFNAME in $VAR(@)

--- a/templates-skeleton/interface-templates/traffic-policy/out/node.def
+++ b/templates-skeleton/interface-templates/traffic-policy/out/node.def
@@ -1,4 +1,5 @@
 type: txt
+priority: 620
 help: Egress traffic policy for interface
 allowed: /opt/vyatta/sbin/vyatta-qos.pl --list-policy out
 update: /opt/vyatta/sbin/vyatta-qos.pl --update-interface $IFNAME out $VAR(@)

--- a/templates/traffic-policy/node.def
+++ b/templates/traffic-policy/node.def
@@ -1,2 +1,2 @@
-priority: 900
+priority: 300
 help: Quality of Service (QOS) policy type


### PR DESCRIPTION
Traffic-policy should exist before we can attach it to an interface
The interface should exist before we can attach traffic-policy to it

(cherry picked from commit b8786cd1044b117e4629689efa7e632b0d47d271)

https://phabricator.vyos.net/T4618

Before fix:
```
set interfaces ethernet eth1 vif 10 traffic-policy out 'SHAPER'
set traffic-policy shaper SHAPER bandwidth '1gbit'
set traffic-policy shaper SHAPER default bandwidth '1gbit'

vyos@r1# commit
[ interfaces ethernet eth1 vif 10 traffic-policy out SHAPER ]
eth1.10 not present yet, traffic-policy will be applied later

[edit]
vyos@r1#
```
After fix:
```
set interfaces ethernet eth1 vif 10 traffic-policy out 'SHAPER'
set traffic-policy shaper SHAPER bandwidth '1gbit'
set traffic-policy shaper SHAPER default bandwidth '1gbit'

vyos@r1# commit
[edit]
vyos@r1# sudo tc qdisc show dev eth1.10
qdisc htb 1: root refcnt 2 r2q 625 default 0x2 direct_packets_stat 0 direct_qlen 1000
qdisc sfq 8003: parent 1:2 limit 127p quantum 1518b depth 127 divisor 1024 
[edit]
vyos@r1# 
```