### PR TITLE
trafic-policy: T4618: Set correct priority for traffic-policy

### DIFF
--- a/templates-skeleton/interface-templates/traffic-policy/in/node.def
+++ b/templates-skeleton/interface-templates/traffic-policy/in/node.def
@@ -1,4 +1,5 @@
 type: txt
+priority: 620
 help: Ingress traffic policy for interface
 allowed: /opt/vyatta/sbin/vyatta-qos.pl --list-policy in
 update: /opt/vyatta/sbin/vyatta-qos.pl --update-interface $IFNAME in $VAR(@)

--- a/templates-skeleton/interface-templates/traffic-policy/out/node.def
+++ b/templates-skeleton/interface-templates/traffic-policy/out/node.def
@@ -1,4 +1,5 @@
 type: txt
+priority: 620
 help: Egress traffic policy for interface
 allowed: /opt/vyatta/sbin/vyatta-qos.pl --list-policy out
 update: /opt/vyatta/sbin/vyatta-qos.pl --update-interface $IFNAME out $VAR(@)

--- a/templates/traffic-policy/node.def
+++ b/templates/traffic-policy/node.def
@@ -1,2 +1,2 @@
-priority: 900
+priority: 300
 help: Quality of Service (QOS) policy type


### PR DESCRIPTION
Traffic-policy should be exist before than we can attach it
to an interface
The interface should exist before we can attach traffic-policy to it

(cherry picked from commit b8786cd1044b117e4629689efa7e632b0d47d271)


https://phabricator.vyos.net/T4618

Before fix:
```
set interfaces ethernet eth1 vif 10 traffic-policy out 'SHAPER'
set traffic-policy shaper SHAPER bandwidth '1gbit'
set traffic-policy shaper SHAPER default bandwidth '1gbit'

vyos@r1# commit
[ interfaces ethernet eth1 vif 10 traffic-policy out SHAPER ]
eth1.10 not present yet, traffic-policy will be applied later

[edit]
vyos@r1#
```
After fix:
```
set interfaces ethernet eth1 vif 10 traffic-policy out 'SHAPER'
set traffic-policy shaper SHAPER bandwidth '1gbit'
set traffic-policy shaper SHAPER default bandwidth '1gbit'

vyos@r1# commit
[edit]
vyos@r1# sudo tc qdisc show dev eth1.10
qdisc htb 1: root refcnt 2 r2q 625 default 0x2 direct_packets_stat 0 direct_qlen 1000
qdisc sfq 8003: parent 1:2 limit 127p quantum 1518b depth 127 divisor 1024 
[edit]
vyos@r1# 
```