### PR TITLE
traffic-policy: T2721: Set fq-codel as default leaf queuing discipline for shaper/HTB

### DIFF
--- a/templates/traffic-policy/shaper/node.tag/class/node.tag/queue-type/node.def
+++ b/templates/traffic-policy/shaper/node.tag/class/node.tag/queue-type/node.def
@@ -1,5 +1,5 @@
 type: txt
-default: "fair-queue"
+default: "fq-codel"
 syntax:expression: $VAR(@) in "fq-codel", "fair-queue", "priority", "drop-tail", "random-detect";\
                    "Unknown queue-type"
 help: Queue type for this class

--- a/templates/traffic-policy/shaper/node.tag/default/queue-type/node.def
+++ b/templates/traffic-policy/shaper/node.tag/default/queue-type/node.def
@@ -1,5 +1,5 @@
 type: txt
-default: "fair-queue"
+default: "fq-codel"
 syntax:expression: $VAR(@) in "fq-codel", "fair-queue", "priority", "drop-tail", "random-detect";\
                    "Unknown queue-type"
 help: Queue type for default traffic


### PR DESCRIPTION
## Change Summary
Set fq-codel as the default queuing discipline for the shaper traffic-policy if `queue-type` has not been configured.

[fq-codel](https://www.bufferbloat.net/projects/codel/wiki) has been the default qdisc for [OpenWRT](https://openwrt.org) as well as [systemd](https://systemd.io) (and thus various linux distributions) for a decent while now. It has proven itself to be a highly effective qdisc for fighting bufferbloat whilst maintaining high link utilization. The combination of HTB + fq-codel has also seen wide deployment in cases when additional traffic classification and/or rate/burst management is required.

Even the VyOS documentation recommends the use of shaper/HTB with fq-codel in cases where the user is not sure what qdisc to be using:
> If you are looking for a policy for your outbound traffic but you don’t know which one you need and you don’t want to go through every possible policy shown here, our bet is that highly likely you are looking for a [Shaper](https://docs.vyos.io/en/equuleus/configuration/trafficpolicy/index.html#shaper) policy and you want to [set its queues](https://docs.vyos.io/en/equuleus/configuration/trafficpolicy/index.html#embed) as FQ-CoDel.

This change will allow the configuration of a shaper traffic-policy with suitable defaults, saving the pain of having to specify fq-codel as a `queue-type` for every class.

The appropriate documentation update PR is [here](https://github.com/vyos/vyos-documentation/pull/851).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://phabricator.vyos.net/T2721

## Component(s) name
traffic-policy

## Proposed changes
Update the shaper default and class `queue-type` node.def files to use `fq-codel` by default.

## How to test

1. Create a shaper traffic-policy and do not specify the `queue-type` for configured classes/default.
2. Apply the traffic-policy to an interface
3. Run: `tc qdisc show dev <iface>` to validate each leaf qdisc is `fq-codel`.

Alternatively run the operation mode command: `show configuration all` and validate the `queue-type` is `fq-codel`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
