### PR TITLE
traffic-policy: T4688: add support for limiter exceed/notexceed actions

### DIFF
--- a/lib/Vyatta/Qos/LimiterClass.pm
+++ b/lib/Vyatta/Qos/LimiterClass.pm
@@ -28,6 +28,8 @@ my %fields = (
     priority => undef,
     burst    => undef,
     rate     => undef,
+    exceedact => undef,
+    notexceedact => undef,
     _match   => undef,
 );
 
@@ -57,6 +59,9 @@ sub _define {
     defined $self->{burst} or die "burst must be defined for $level\n";
 
     $self->{priority} = $config->returnValue("priority");
+
+    $self->{exceedact} = $config->returnValue("exceed-action");
+    $self->{notexceedact} = $config->returnValue("notexceed-action");
 
     foreach my $match ( $config->listNodes("match") ) {
         $config->setLevel("$level match $match");

--- a/lib/Vyatta/Qos/TrafficLimiter.pm
+++ b/lib/Vyatta/Qos/TrafficLimiter.pm
@@ -83,7 +83,8 @@ sub commands {
     foreach my $class (@$classes) {
 	my $id = $class->{id};
 	my $police = " action police rate " . $class->{rate}
-		   . " conform-exceed drop burst " . $class->{burst};
+		   . " conform-exceed " . $class->{exceedact} . "/"
+		   . $class->{notexceedact} . " burst " . $class->{burst};
 
 	if ($id == 0) {
 	    $id = $maxid + 1;

--- a/templates/traffic-policy/limiter/node.tag/class/node.tag/exceed-action/node.def
+++ b/templates/traffic-policy/limiter/node.tag/class/node.tag/exceed-action/node.def
@@ -1,0 +1,10 @@
+type: txt
+help: Default action for packets exceeding the limiter (default: drop)
+default: "drop"
+syntax:expression: $VAR(@) in "continue", "drop", "ok", "reclassify", "pipe"
+
+val_help: continue; Don't do anything, just continue with the next action in line
+val_help: drop; Drop the packet immediately
+val_help: ok; Accept the packet
+val_help: reclassify; Treat the packet as non-matching to the filter this action is attached to and continue with the next filter in line (if any)
+val_help: pipe; Pass the packet to the next action in line

--- a/templates/traffic-policy/limiter/node.tag/class/node.tag/notexceed-action/node.def
+++ b/templates/traffic-policy/limiter/node.tag/class/node.tag/notexceed-action/node.def
@@ -1,0 +1,10 @@
+type: txt
+help: Default action for packets not exceeding the limiter (default: ok)
+default: "ok"
+syntax:expression: $VAR(@) in "continue", "drop", "ok", "reclassify", "pipe"
+
+val_help: continue; Don't do anything, just continue with the next action in line
+val_help: drop; Drop the packet immediately
+val_help: ok; Accept the packet
+val_help: reclassify; Treat the packet as non-matching to the filter this action is attached to and continue with the next filter in line (if any)
+val_help: pipe; Pass the packet to the next action in line

--- a/templates/traffic-policy/limiter/node.tag/default/exceed-action/node.def
+++ b/templates/traffic-policy/limiter/node.tag/default/exceed-action/node.def
@@ -1,0 +1,10 @@
+type: txt
+help: Default action for packets exceeding the limiter (default: drop)
+default: "drop"
+syntax:expression: $VAR(@) in "continue", "drop", "ok", "reclassify", "pipe"
+
+val_help: continue; Don't do anything, just continue with the next action in line
+val_help: drop; Drop the packet immediately
+val_help: ok; Accept the packet
+val_help: reclassify; Treat the packet as non-matching to the filter this action is attached to and continue with the next filter in line (if any)
+val_help: pipe; Pass the packet to the next action in line

--- a/templates/traffic-policy/limiter/node.tag/default/notexceed-action/node.def
+++ b/templates/traffic-policy/limiter/node.tag/default/notexceed-action/node.def
@@ -1,0 +1,10 @@
+type: txt
+help: Default action for packets not exceeding the limiter (default: ok)
+default: "ok"
+syntax:expression: $VAR(@) in "continue", "drop", "ok", "reclassify", "pipe"
+
+val_help: continue; Don't do anything, just continue with the next action in line
+val_help: drop; Drop the packet immediately
+val_help: ok; Accept the packet
+val_help: reclassify; Treat the packet as non-matching to the filter this action is attached to and continue with the next filter in line (if any)
+val_help: pipe; Pass the packet to the next action in line


### PR DESCRIPTION
## Change Summary

Adds configuration nodes to set the exceed action and the non-exceed action for the limiter traffic policy for additional customization with respect to what the limiter can do (currently it can only drop packets exceeding the configured bandwidth). Uses cases for this are listed in the Phabricator task.

Documentation update PR is [here](https://github.com/vyos/vyos-documentation/pull/852).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://phabricator.vyos.net/T4688

## Component(s) name
traffic-policy

## Proposed changes
Adds new configuration nodes `exceed-action` and `notexceed-action` (names taken from tc-police(8)) to the default and all class nodes under the limiter traffic-policy. An example config is shown below:
```
traffic-policy {
    limiter test {
        default {
            bandwidth 1gbit

            exceed-action drop
            notexceed-action ok
        }

        class 100 {
            bandwidth 500mbit
            priority 1

            exceed-action reclassify
            notexceed-action ok
        }
    }
}
```

## How to test

1. Create a limiter traffic-policy using a configuration similar to the one given above
2. Apply the traffic-policy to an interface's ingress direction
3. Run: `tc filter show dev <iface> ingress` to validate the `conform-exceed` keyword is populated with the correct action(s).

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
